### PR TITLE
Fix typos in test names

### DIFF
--- a/Tests/WrkstrmMainTests/CollectionTests.swift
+++ b/Tests/WrkstrmMainTests/CollectionTests.swift
@@ -8,7 +8,7 @@ struct CollectionTests {
   let randomElements = [5, 4, 1, 6, 0, -10]
 
   @Test
-  func tearchWithIncreasingElements() {
+  func searchWithIncreasingElements() {
     #expect(increasingElements.search(key: 3) == 1)
   }
 

--- a/Tests/WrkstrmMainTests/ListTests.swift
+++ b/Tests/WrkstrmMainTests/ListTests.swift
@@ -22,7 +22,7 @@ struct ListTests {
   }
 
   @Test
-  func testBasticSingleLinkedLoop() {
+  func testBasicSingleLinkedLoop() {
     let three = List.single(3, next: two)
     let four = List.single(4, next: three)
     let five = List.single(5, next: four)


### PR DESCRIPTION
## Summary
- rename `tearchWithIncreasingElements` to `searchWithIncreasingElements`
- rename `testBasticSingleLinkedLoop` to `testBasicSingleLinkedLoop`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688c446b433c8333a2249368967dfb79