### PR TITLE
Preserve order with unique() and new tests

### DIFF
--- a/Sources/WrkstrmMain/Extensions/Sequence+Unique.swift
+++ b/Sources/WrkstrmMain/Extensions/Sequence+Unique.swift
@@ -9,6 +9,13 @@ extension Sequence where Iterator.Element: Hashable {
   ///
   /// - Returns: An array containing the unique elements of the sequence.
   func unique() -> [Iterator.Element] {
-    Array(reduce(into: Set<Iterator.Element>()) { $0.insert($1) })
+    var seen = Set<Iterator.Element>()
+    var result: [Iterator.Element] = []
+    for element in self {
+      if seen.insert(element).inserted {
+        result.append(element)
+      }
+    }
+    return result
   }
 }

--- a/Tests/WrkstrmMainTests/SequenceUniqueTests.swift
+++ b/Tests/WrkstrmMainTests/SequenceUniqueTests.swift
@@ -1,0 +1,20 @@
+import Testing
+
+@testable import WrkstrmMain
+
+struct SequenceUniqueTests {
+
+  @Test
+  func testUniquePreservesOrder() {
+    let input = [3, 1, 2, 3, 2, 1]
+    let unique = input.unique()
+    #expect(unique == [3, 1, 2])
+  }
+
+  @Test
+  func testUniqueWithAlreadyUnique() {
+    let input = [1, 2, 3]
+    let unique = input.unique()
+    #expect(unique == input)
+  }
+}


### PR DESCRIPTION
## Summary
- update `unique()` to retain element order
- add unit tests for `Sequence.unique()`

## Testing
- `swift test --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688c44776c888333a16def848d939111