### PR TITLE
Fix endIndex and iteration test

### DIFF
--- a/Sources/WrkstrmMain/CustomCollections/Structs/IndexedCollection.swift
+++ b/Sources/WrkstrmMain/CustomCollections/Structs/IndexedCollection.swift
@@ -29,7 +29,7 @@ struct IndexedCollection<Base: RandomAccessCollection>: RandomAccessCollection {
   var startIndex: Index { base.startIndex }
 
   /// The end index of the collection.
-  var endIndex: Index { base.startIndex }
+  var endIndex: Index { base.endIndex }
 
   /// Returns the index immediately after the given index.
   ///

--- a/Tests/WrkstrmMainTests/IndexedCollectionTests.swift
+++ b/Tests/WrkstrmMainTests/IndexedCollectionTests.swift
@@ -19,4 +19,20 @@ struct IndexedCollectionTests {
       #expect(element == expectedResults[index].1)
     }
   }
+
+  @Test
+  func testIterationReachesLastElement() {
+    let array = [1, 2, 3]
+    let collection = IndexedCollection(base: array)
+
+    var lastIndex: Int?
+    var lastElement: Int?
+    for (index, element) in collection {
+      lastIndex = index
+      lastElement = element
+    }
+
+    #expect(lastIndex == array.index(before: array.endIndex))
+    #expect(lastElement == array.last)
+  }
 }


### PR DESCRIPTION
## Summary
- fix `IndexedCollection.endIndex`
- ensure IndexedCollection iteration hits the last element

## Testing
- `swift test --enable-code-coverage --parallel --filter WrkstrmMainTests`

------
https://chatgpt.com/codex/tasks/task_e_688c4478a96c83339d46d8c315d8aefb