### PR TITLE
Add string multiplication operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Example Extensions:
 - `camelCaseToKebabCase()`: Convert a camelCase string to kebab-case.
 - `containsUniqueChars()`: Check if a string contains all unique characters.
 - `isPermutation(_:)`: Check if a string is a permutation of another string.
+- ``*`` operator: Repeat a string by multiplying it with an integer.
 
 ### Collection Extensions
 

--- a/Sources/WrkstrmMain/Extensions/String/String+Repeat.swift
+++ b/Sources/WrkstrmMain/Extensions/String/String+Repeat.swift
@@ -1,0 +1,20 @@
+/// An extension on `String` providing a multiplication operator to repeat strings.
+extension String {
+  /// Repeats the string a specified number of times using the `*` operator.
+  ///
+  /// Example:
+  ///
+  /// ```swift
+  /// let laugh = "ha" * 3
+  /// // laugh == "hahaha"
+  /// ```
+  ///
+  /// - Parameters:
+  ///   - left: The string to repeat.
+  ///   - right: The number of times to repeat the string. Must be non-negative.
+  /// - Returns: A new string consisting of `left` repeated `right` times.
+  public static func * (left: String, right: Int) -> String {
+    String(repeating: left, count: right)
+  }
+}
+

--- a/Tests/WrkstrmMainTests/StringRepeatTests.swift
+++ b/Tests/WrkstrmMainTests/StringRepeatTests.swift
@@ -1,0 +1,17 @@
+import Testing
+
+@testable import WrkstrmMain
+
+struct StringRepeatTests {
+
+  @Test
+  func testMultiplication() {
+    #expect("ha" * 3 == "hahaha")
+  }
+
+  @Test
+  func testZeroMultiplication() {
+    #expect("ha" * 0 == "")
+  }
+}
+


### PR DESCRIPTION
## Summary
- extend `String` with `*` to repeat a string
- document operator in README
- test string multiplication including zero times

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689165edfcf8833390d7cd09bb9d72fc