### PR TITLE
Document Injectable protocol and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,31 +99,36 @@ project by tapping into a few key extension points:
   existing types such as `SortedArray` or by conforming to Swift's `Collection`
   protocols.
 
-- **Dependency injection** – Adopt the `Injectable` protocol to keep
-  dependencies loosely coupled. Conforming types can have resources injected
-  from the outside and verify that everything is wired correctly.
-
-  ```swift
-  struct NetworkService {
-      func request(_ path: String) { /* ... */ }
-  }
-
-  final class UserViewModel: Injectable {
-      typealias Resource = NetworkService
-      private var service: NetworkService?
-
-      func inject(_ resource: NetworkService) {
-          service = resource
-      }
-
-      func assertDependencies() {
-          precondition(service != nil, "NetworkService must be injected")
-      }
-  }
-  ```
-
 These hooks make `WrkstrmMain` easy to integrate with project‑specific types
 and behaviors.
+
+## 🧩 Dependency Injection
+
+Adopt the ``Injectable`` protocol to keep dependencies loosely coupled. Conforming
+types can accept resources from the outside and verify that everything is wired
+correctly.
+
+```swift
+struct NetworkService {
+    func request(_ path: String) { /* ... */ }
+}
+
+final class UserViewModel: Injectable {
+    typealias Resource = NetworkService
+    private var service: NetworkService?
+
+    func inject(_ resource: NetworkService) {
+        service = resource
+    }
+
+    func assertDependencies() {
+        precondition(service != nil, "NetworkService must be injected")
+    }
+}
+```
+
+See the [Injectable documentation](Sources/WrkstrmMain/Documentation.docc/Injectable.md)
+for a deeper explanation and more examples.
 
 ## 🤝 Contributing
 

--- a/Sources/WrkstrmMain/Documentation.docc/Injectable.md
+++ b/Sources/WrkstrmMain/Documentation.docc/Injectable.md
@@ -1,0 +1,39 @@
+# ``Injectable``
+
+A protocol for injecting external resources into a type and verifying that dependencies are configured.
+
+## Topics
+
+### Managing Dependencies
+- ``Resource``
+- ``inject(_:)``
+- ``assertDependencies()``
+
+## Overview
+
+`Injectable` decouples collaborators by allowing dependencies to be supplied from
+the outside. Conforming types declare an associated ``Resource`` to represent the
+dependency. Use ``inject(_:)`` to store the resource and ``assertDependencies()``
+to ensure everything is wired correctly.
+
+## Example
+
+```swift
+struct NetworkService {
+    func request(_ path: String) { /* ... */ }
+}
+
+final class UserViewModel: Injectable {
+    typealias Resource = NetworkService
+    private var service: NetworkService?
+
+    func inject(_ resource: NetworkService) {
+        service = resource
+    }
+
+    func assertDependencies() {
+        precondition(service != nil, "NetworkService must be injected")
+    }
+}
+```
+


### PR DESCRIPTION
## Summary
- document `Injectable` protocol with overview, topics, and usage example
- add README section on dependency injection and link to `Injectable` doc

## Testing
- `swift test`
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689abd582eb483338b83fa38e2c69951