### PR TITLE
docs: add path filter documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,11 @@ struct Wrapper: Decodable {
 }
 ```
 
-### Path-Filtering Utilities on `[String]`
+### Path Utilities
 
-See [`String+Source.swift`](Sources/WrkstrmMain/Extensions/String/String+Source.swift).
+Filter arrays of path strings using the `sourceFiles`, `nibFiles`, `baseLocalizedNibFiles`, and `unlocalizedNibFiles` properties.
+
+See the [Source File Filters documentation](Sources/WrkstrmMain/Documentation.docc/SourceFileFilters.md) for more examples.
 
 ```swift
 let paths = ["View.swift", "Main.storyboard", "Base.lproj/Main.storyboard"]

--- a/Sources/WrkstrmMain/Documentation.docc/SourceFileFilters.md
+++ b/Sources/WrkstrmMain/Documentation.docc/SourceFileFilters.md
@@ -1,0 +1,31 @@
+# Source File Filters
+
+Utilities on arrays of path strings for picking out specific kinds of files.
+
+## Overview
+
+The `[String]` extension defines four computed properties that help separate source and Interface Builder files from a mixed list of paths.
+
+## Examples
+
+```swift
+let files = [
+    "View.swift",
+    "Main.storyboard",
+    "Base.lproj/Main.storyboard",
+    "Base.lproj/Settings.xib",
+    "Debug/Main.storyboard"
+]
+
+files.sourceFiles
+// ["View.swift"]
+
+files.nibFiles
+// ["Main.storyboard", "Base.lproj/Main.storyboard", "Base.lproj/Settings.xib", "Debug/Main.storyboard"]
+
+files.baseLocalizedNibFiles
+// ["Base.lproj/Main.storyboard", "Base.lproj/Settings.xib"]
+
+files.unlocalizedNibFiles
+// ["Main.storyboard"]
+```


### PR DESCRIPTION
## Summary
- document array path filter helpers
- mention path utilities in README

## Testing
- `swift test`
- `swiftlint` *(fails: command not found; attempted apt-get install but package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689abf9c64808333ac7c98d5a0ef0f02