### PR TITLE
Add additional string repeat tests

### DIFF
--- a/Tests/WrkstrmMainTests/StringRepeatTests.swift
+++ b/Tests/WrkstrmMainTests/StringRepeatTests.swift
@@ -1,4 +1,4 @@
-import Testing
+@_spi(Experimental) import Testing
 
 @testable import WrkstrmMain
 
@@ -12,5 +12,25 @@ struct StringRepeatTests {
   @Test
   func testZeroMultiplication() {
     #expect("ha" * 0 == "")
+  }
+
+#if swift(>=6.2)
+  // Guard against undefined behavior by ensuring negative repeat counts
+  // trigger a precondition failure rather than silently producing a value.
+  @Test
+  func testNegativeMultiplication() async {
+    await #expect(processExitsWith: .failure) {
+      _ = "ha" * -1
+    }
+  }
+#endif
+
+  // Verifies the repeat algorithm scales for large counts and returns
+  // the expected character count.
+  @Test
+  func testLargeMultiplication() {
+    let repeatCount = 1_000
+    let result = "ha" * repeatCount
+    #expect(result.count == 2 * repeatCount)
   }
 }


### PR DESCRIPTION
## Summary
- add conditional test verifying negative repeats trigger failure
- ensure large repeat counts produce expected length
- document reasoning behind negative and large multiplier tests

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68a43febfc30833399b7cf4e5bbe02e0