### PR TITLE
Add tests for optional flattening

### DIFF
--- a/Tests/WrkstrmMainTests/OptionalFlattenableTests.swift
+++ b/Tests/WrkstrmMainTests/OptionalFlattenableTests.swift
@@ -1,0 +1,54 @@
+import Testing
+
+@testable import WrkstrmMain
+
+// These tests guard the behavior of `flattened()` which is used to collapse
+// arbitrarily nested optionals and custom `AnyFlattenable` types. Ensuring this
+// logic works prevents callers from dealing with unexpected levels of
+// optionality or unflattened wrapper types.
+struct OptionalFlattenableTests {
+
+  struct Wrapper: AnyFlattenable {
+    let value: Any?
+
+    func flattened() -> Any? {
+      if let flattenable = value as? AnyFlattenable {
+        return flattenable.flattened()
+      }
+      return value
+    }
+  }
+
+  // Verifies a basic optional unwraps to its contained value.
+  @Test
+  func testSingleLevelOptional() {
+    let value: Int? = 42
+    let flattened = value.flattened() as? Int
+    #expect(flattened == 42)
+  }
+
+  // Ensures the flattening recurses through multiple optional layers.
+  @Test
+  func testNestedOptional() {
+    let value: Int??? = 42
+    let flattened = value.flattened() as? Int
+    #expect(flattened == 42)
+  }
+
+  // Confirms custom `AnyFlattenable` implementations are also collapsed.
+  @Test
+  func testCustomAnyFlattenable() {
+    let nested: Wrapper? = Wrapper(value: Wrapper(value: 7))
+    let flattened = nested.flattened() as? Int
+    #expect(flattened == 7)
+  }
+
+  // Checks that a `nil` value remains `nil` after flattening.
+  @Test
+  func testNilValue() {
+    let value: Int?? = .some(nil)
+    let flattened = value.flattened()
+    #expect(flattened == nil)
+  }
+}
+


### PR DESCRIPTION
## Summary
- add OptionalFlattenableTests covering single-level and nested optionals
- verify custom AnyFlattenable types and nil flattening
- document why flattening coverage is important

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68a43ff525dc8333bd8f342c2f810c92