### PR TITLE
Add permutation edge case tests

### DIFF
--- a/Tests/WrkstrmMainTests/StringTests.swift
+++ b/Tests/WrkstrmMainTests/StringTests.swift
@@ -28,4 +28,14 @@ struct StringTests {
   func testIsPermutation() {
     #expect("aa".isPermutation("aa"))
   }
+
+  @Test
+  func testPermutationFalsePositive() {
+    #expect(!"ad".isPermutation("bc"))
+  }
+
+  @Test
+  func testPermutationPositive() {
+    #expect("ab".isPermutation("ba"))
+  }
 }


### PR DESCRIPTION
## Summary
- add failing test showing false positive for `isPermutation` with "ad" and "bc"
- add positive permutation test for "ab" and "ba"

## Testing
- `swift test` *(fails: testPermutationFalsePositive)*

------
https://chatgpt.com/codex/tasks/task_e_68a48a81437c8333a5a27d1d32e7be7c