### PR TITLE
Fix Random.mixed length by excluding combining emoji

### DIFF
--- a/Sources/WrkstrmMain/Random/Random.swift
+++ b/Sources/WrkstrmMain/Random/Random.swift
@@ -49,11 +49,15 @@ public enum Random {
   /// Emoji characters that:
   /// - are a single Unicode scalar
   /// - have default emoji presentation
+  /// - stand alone as individual grapheme clusters (exclude modifiers/selectors)
   private static let emojiTable: [Character] = {
     (0...0x10FFFF).compactMap { cp in
       guard let scalar = UnicodeScalar(cp),
         scalar.properties.isEmoji,
-        scalar.properties.isEmojiPresentation
+        scalar.properties.isEmojiPresentation,
+        scalar.properties.isGraphemeBase,
+        !scalar.properties.isEmojiModifier,
+        !scalar.properties.isVariationSelector
       else {
         return nil
       }


### PR DESCRIPTION
## Summary
- avoid selecting emoji modifiers and variation selectors when building random emoji table
- ensure mixed random strings always honor the requested length

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68a49b0b43d8833391e01b59c9f766a8