### PR TITLE
Refactor guard usage and optional comparison

### DIFF
--- a/Sources/WrkstrmMain/CustomCollections/Classes/BinaryTree.swift
+++ b/Sources/WrkstrmMain/CustomCollections/Classes/BinaryTree.swift
@@ -60,21 +60,19 @@ public class BinaryTree<Value: Comparable> {
   @discardableResult
   public func insert(_ value: Value) -> BinaryTree {
     if value < self.value {
-      if let left {
-        return left.insert(value)
-      } else {
+      guard let left else {
         let newNode = BinaryTree(value, parent: self)
-        left = newNode
+        self.left = newNode
         return newNode
       }
+      return left.insert(value)
     } else {
-      if let right {
-        return right.insert(value)
-      } else {
+      guard let right else {
         let newNode = BinaryTree(value, parent: self)
-        right = newNode
+        self.right = newNode
         return newNode
       }
+      return right.insert(value)
     }
   }
 

--- a/Sources/WrkstrmMain/Extensions/Optional/OptionalComparisons.swift
+++ b/Sources/WrkstrmMain/Extensions/Optional/OptionalComparisons.swift
@@ -6,7 +6,7 @@
 /// - `nil` is considered less than any non-nil value.
 public func < <Wrapped: Comparable>(lhs: Wrapped?, rhs: Wrapped?) -> Bool {
   switch (lhs, rhs) {
-  case let (l?, r?):
+  case (let l?, let r?):
     return l < r
   case (nil, .some):
     return true


### PR DESCRIPTION
## Summary
- refactor BinaryTree insertion to use guard early exits
- adjust optional comparison pattern binding

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68a608df2b7083338542d7c14e134db7