### PR TITLE
Resolve lint warnings in optional comparisons

### DIFF
--- a/Sources/WrkstrmMain/Extensions/Optional/OptionalComparisons.swift
+++ b/Sources/WrkstrmMain/Extensions/Optional/OptionalComparisons.swift
@@ -6,7 +6,7 @@
 /// - `nil` is considered less than any non-nil value.
 public func < <Wrapped: Comparable>(lhs: Wrapped?, rhs: Wrapped?) -> Bool {
   switch (lhs, rhs) {
-  case (let l?, let r?):
+  case (.some(let l), .some(let r)):
     return l < r
   case (nil, .some):
     return true


### PR DESCRIPTION
## Summary
- fix optional comparison switch case to bind `.some` values

## Testing
- `swift format lint Sources/WrkstrmMain/Extensions/Optional/OptionalComparisons.swift`
- `swift test > /tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68a6402039948333a03d2800b63cbe1d