### PR TITLE
Clarify optional comparison docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Example Extensions:
 
 ### `Optional` Comparable Extension
 
-- `Optional<T>` where `T: Comparable & Equatable`: Adds comparison functionality to Optionals.
+  - `Optional<T>` where `T: Comparable`: Adds `<` and `>` comparison operators for optional values without requiring a full `Comparable` conformance.
 
 ### Random String Utilities
 


### PR DESCRIPTION
## Summary
- Align README optional comparison section with implementation by noting only `Comparable` requirement and `<`/`>` operators

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68aa4cb9c8b083339742f6e7d2b1f4eb